### PR TITLE
add files with [digit]-[digit]-[digit] filenames

### DIFF
--- a/app/webpack/config.dev.babel.js
+++ b/app/webpack/config.dev.babel.js
@@ -46,11 +46,11 @@ export default {
         'css-loader',
       ],
     }, {
-      test: /\.json$/,
+      test: /(?:\.json|\d+-\d+-\d+)$/,
       include: path.resolve(__dirname, '../node_modules'),
       loader: 'json-loader',
     }, {
-      test: /\.json$/,
+      test: /(?:\.json|\d+-\d+-\d+)$/,
       exclude: path.resolve(__dirname, '../node_modules'),
       use: [
         `json-schema-example-loader?${JSON.stringify(config)}`,


### PR DESCRIPTION
Process jsonschema files named [digit]-[digit]-[digit] (e.g. 1-0-0, 2-1-2 etc. ) during discovery scans